### PR TITLE
bluespin-dx: install AirPlay 2 PipeWire from lorbus/misc COPR

### DIFF
--- a/build_files/build.sh
+++ b/build_files/build.sh
@@ -81,6 +81,18 @@ if [[ "${IMAGE_NAME}" == "bluespin-dx" ]]; then
     dnf -y copr enable lorbus/calls
     dnf -y install calls
     dnf -y copr disable lorbus/calls
+
+    # PipeWire with AirPlay 2 (RAOP) support, from the lorbus/misc COPR.
+    # Replaces the base pipewire with the 1.7.0 snapshot; the 'pipewire*' glob
+    # also upgrades the already-installed pipewire-config-raop (which enables
+    # RAOP discovery). The COPR must have a fedora-44 chroot matching the
+    # bluefin-dx:latest base.
+    dnf -y copr enable lorbus/misc
+    dnf -y upgrade 'pipewire*'
+    dnf -y copr disable lorbus/misc
+    # dnf upgrade is a no-op (exit 0) if the COPR lacks an fc44 build, which
+    # would silently ship the base pipewire — fail loudly instead.
+    rpm -q pipewire | grep -q git || { echo "ERROR: lorbus/misc pipewire not installed"; exit 1; }
 fi
 
 # Surface Variant


### PR DESCRIPTION
Replaces the base PipeWire in `bluespin-dx` with the 1.7.0 snapshot from [lorbus/misc](https://copr.fedorainfracloud.org/coprs/lorbus/misc/build/10694318/), adding AirPlay 2 (RAOP) sink support. `dnf upgrade 'pipewire*'` pulls all pipewire subpackages up together, including the installed `pipewire-config-raop` that enables RAOP discovery. A guard fails the build if the COPR package wasn't picked up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)